### PR TITLE
Support Pyspark 3.1.* and 3.2*

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -50,8 +50,8 @@ dependencies:
     - databricks-sql-connector==2.5.1
     - semver==3.0.0
     - pip:
-        - pyspark==3.1.1
-        - delta-spark==1.0.0
+        - pyspark==3.2.0
+        - delta-spark==2.0.0
         - dependency-injector==4.41.0
         - azure-functions==1.14.0
         - dbx==0.8.11

--- a/environment.yml
+++ b/environment.yml
@@ -40,8 +40,6 @@ dependencies:
     - fastapi==0.95.1
     - httpx==0.24.0
     - trio==0.22.0
-    - pyspark>=3.3.0,<3.4.0
-    - delta-spark>=2.2.0,<2.4.0
     - openjdk==11.0.15    
     - python-dotenv==1.0.0
     - mkdocstrings==0.21.2
@@ -52,6 +50,8 @@ dependencies:
     - databricks-sql-connector==2.5.1
     - semver==3.0.0
     - pip:
+        - pyspark==3.1.1
+        - delta-spark==1.0.0
         - dependency-injector==4.41.0
         - azure-functions==1.14.0
         - dbx==0.8.11


### PR DESCRIPTION
Setup Github Actions support for tests on Pyspark 3.1.* and 3.2.* to resolve #260 