### PR TITLE
Preview Support of Pyspark 3.4.0

### DIFF
--- a/.github/workflows/sonarcloud_reusable.yml
+++ b/.github/workflows/sonarcloud_reusable.yml
@@ -47,9 +47,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
-        pyspark: ["3.3.2"]
-        delta-spark: ["2.3.0"]
+        python-version: ["3.11"]
+        pyspark: ["3.4.0"]
+        delta-spark: ["2.4.0rc1"]
     runs-on: ${{ matrix.os }} 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,14 @@
 
 name: 'Reusable Test Workflow'
 
+# on:
+#   workflow_call:
+
 on:
-  workflow_call:
+  # Trigger the workflow on push to develop
+  push:
+    branches:
+      - feature/00275
 
 jobs:
   job_test_python_pyspark_versions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       strategy:
         matrix:
           os: [ubuntu-latest]
-          python-version: ["3.8", "3.9", "3.10"]
-          pyspark: ["3.3.0", "3.3.1", "3.3.2"]
+          python-version: ["3.8", "3.9", "3.10", "3.11"]
+          pyspark: ["3.3.0", "3.3.1", "3.3.2", "3.4.0"]
           include:
             - pyspark: "3.3.0"
               delta-spark: "2.2.0"
@@ -34,6 +34,8 @@ jobs:
               delta-spark: "2.3.0"
             - pyspark: "3.3.2"
               delta-spark: "2.3.0"
+            - pyspark: "3.4.0"
+              delta-spark: "2.4.0rc1"              
       runs-on: ${{ matrix.os }}
       steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         run:
           shell: bash -l {0}
       strategy:
+        fail-fast: false
         matrix:
           os: [ubuntu-latest]
           python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,13 @@
     "azureFunctions.projectLanguage": "Python",
     "azureFunctions.projectRuntime": "~4",				
     "python.linting.enabled": true,
-    "python.linting.pylintEnabled": true,
+    "python.linting.pylintEnabled": false,
     "python.formatting.autopep8Path": "/opt/conda/bin/autopep8",
     "python.formatting.yapfPath": "/opt/conda/bin/yapf",
     "python.linting.flake8Path": "/opt/conda/bin/flake8",
     "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
     "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-    "python.linting.pylintPath": "/opt/conda/bin/pylint",
+    // "python.linting.pylintPath": "/opt/conda/bin/pylint",
     "python.testing.pytestArgs": [
         "--cov=.",
         "--cov-report=xml:cov.xml",
@@ -19,7 +19,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    // "python.testing.cwd": "${workspaceFolder}",
+    "python.testing.cwd": "${workspaceFolder}",
     "python.analysis.extraPaths": ["${workspaceFolder}"],
     "terminal.integrated.env.osx":{
         "PYTHONPATH": "${workspaceFolder}:${env:PYTHONPATH}"        
@@ -33,5 +33,9 @@
     "git.alwaysSignOff": true,
     "githubPullRequests.ignoredPullRequestBranches": [
         "develop"
-    ]
+    ],
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
 }

--- a/environment.yml
+++ b/environment.yml
@@ -18,8 +18,8 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python>=3.8,<3.11
-    - mkdocs-material==9.1.8
+    - python>=3.8,<3.12
+    - mkdocs-material==9.1.13
     - mkdocs-material-extensions==1.1.1
     - jinja2==3.0.3
     - jinjasql==0.1.8
@@ -27,7 +27,7 @@ dependencies:
     - pytest-mock==3.10.0
     - pytest-cov==4.0.0
     - pip==23.1.2
-    - turbodbc==4.5.10
+    - turbodbc==4.6.0
     - numpy>=1.23.4
     - pandas==1.5.2
     - oauthlib>=3.2.2
@@ -35,21 +35,21 @@ dependencies:
     - azure-identity==1.12.0
     - azure-storage-file-datalake==12.10.1
     - azure-keyvault-secrets==4.7.0
-    - boto3==1.26.123
+    - boto3==1.26.135
     - pyodbc==4.0.39
-    - fastapi==0.95.1
+    - fastapi==0.95.2
     - httpx==0.24.0
     - trio==0.22.0
-    - pyspark>=3.3.0,<3.4.0
-    - delta-spark>=2.2.0,<2.4.0
+    - pyspark>=3.3.0,<3.5.0
+    - delta-spark>=2.2.0,<2.5.0
     - openjdk==11.0.15    
     - python-dotenv==1.0.0
     - mkdocstrings==0.21.2
-    - mkdocstrings-python==0.9.0
+    - mkdocstrings-python==1.0.0
     - mkdocs-macros-plugin==0.7.0
     - pygments==2.15.1
-    - pymdown-extensions==9.11
-    - databricks-sql-connector==2.5.1
+    - pymdown-extensions==10.0.1
+    - databricks-sql-connector==2.5.2
     - semver==3.0.0
     - pip:
         - dependency-injector==4.41.0

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
     - pytest-cov==4.0.0
     - pylint==2.17.4
     - pip==23.1.2
-    - turbodbc==4.6.0
+    - turbodbc==4.5.10
     - numpy>=1.23.4
     - pandas==1.5.2
     - oauthlib>=3.2.2

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
     - pytest==7.3.1
     - pytest-mock==3.10.0
     - pytest-cov==4.0.0
+    - pylint==2.17.4
     - pip==23.1.2
     - turbodbc==4.6.0
     - numpy>=1.23.4
@@ -41,7 +42,6 @@ dependencies:
     - httpx==0.24.0
     - trio==0.22.0
     - pyspark>=3.3.0,<3.5.0
-    - delta-spark>=2.2.0,<2.5.0
     - openjdk==11.0.15    
     - python-dotenv==1.0.0
     - mkdocstrings==0.21.2
@@ -51,7 +51,7 @@ dependencies:
     - pymdown-extensions==10.0.1
     - databricks-sql-connector==2.5.2
     - semver==3.0.0
-    - pip:
+    - pip:    
         - dependency-injector==4.41.0
         - azure-functions==1.14.0
         - dbx==0.8.11
@@ -60,3 +60,5 @@ dependencies:
         - strawberry-graphql[fastapi]==0.176.0
         - nest_asyncio==1.5.6
         - hvac==1.1.0
+        - --extra-index-url https://test.pypi.org/simple/
+        - delta-spark==2.4.0rc1

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ INSTALL_REQUIRES = [
 ]
 
 PYSPARK_PACKAGES = [
-  "pyspark>=3.3.0,<3.4.0",
-  "delta-spark>=2.2.0,<2.4.0",
+  "pyspark>=3.3.0,<3.5.0",
+  "delta-spark>=2.2.0,<2.5.0",
 ]
 
 PIPELINE_PACKAGES = [

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
       "Programming Language :: Python :: 3.8",
       "Programming Language :: Python :: 3.9",
       "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
     ],
     project_urls={
         "Issue Tracker": "https://github.com/rtdip/core/issues",
@@ -80,7 +81,7 @@ setup(
     package_dir={"": "src/sdk/python"},
     include_package_data=True,
     packages=find_packages(where="src/sdk/python"),
-    python_requires=">=3.8, <3.11",
+    python_requires=">=3.8, <3.12",
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_DEPENDENCIES,
     setup_requires=["pytest-runner","setuptools_scm"],

--- a/src/api/v1/graphql.py
+++ b/src/api/v1/graphql.py
@@ -45,27 +45,27 @@ class Query:
       authorization: str = Header(None, include_in_schema=False),
       # authorization: str = Depends(oauth2_scheme)
       ) -> RawResponseQL:
-      try:
-          token = azuread.get_azure_ad_token(authorization)
-          
-          connection = DatabricksSQLConnection(os.environ.get("DATABRICKS_SQL_SERVER_HOSTNAME"), os.environ.get("DATABRICKS_SQL_HTTP_PATH"), token)
+    try:
+        token = azuread.get_azure_ad_token(authorization)
+        
+        connection = DatabricksSQLConnection(os.environ.get("DATABRICKS_SQL_SERVER_HOSTNAME"), os.environ.get("DATABRICKS_SQL_HTTP_PATH"), token)
 
-          parameters = {
-              "business_unit": business_unit,
-              "region": region,
-              "asset": asset,
-              "data_security_level": data_security_level,
-              "data_type": data_type,
-              "tag_names": tag_name,
-              "include_bad_data": include_bad_data,
-              "start_date": str(start_date),
-              "end_date": str(end_date),
-          }
-          data = raw.get(connection, parameters)
-          return RawResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
-      except Exception as e:
-          logging.error(str(e))
-          return HTTPException(status_code=500, detail=str(e))
+        parameters = {
+            "business_unit": business_unit,
+            "region": region,
+            "asset": asset,
+            "data_security_level": data_security_level,
+            "data_type": data_type,
+            "tag_names": tag_name,
+            "include_bad_data": include_bad_data,
+            "start_date": str(start_date),
+            "end_date": str(end_date),
+        }
+        data = raw.get(connection, parameters)
+        return RawResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+    except Exception as e:
+        logging.error(str(e))
+        return HTTPException(status_code=500, detail=str(e))
 
 schema = strawberry.Schema(Query)
         

--- a/src/sdk/python/rtdip_sdk/_sdk_utils/compare_versions.py
+++ b/src/sdk/python/rtdip_sdk/_sdk_utils/compare_versions.py
@@ -14,10 +14,28 @@
 
 from importlib_metadata import version
 from semver.version import Version
+from packaging.version import Version as PyPIVersion
+
+def _get_semver_from_python_version(pypi_ver: PyPIVersion):
+    pre=None
+    if pypi_ver.is_prerelease:
+        pre = "".join(str(i) for i in pypi_ver.pre)
+        pypi_ver = Version(*pypi_ver.release, pre)
+    else:
+        pypi_ver = Version(*pypi_ver.release)
+
+    return pypi_ver
+
+def _get_python_package_version(package_name):
+    pypi_ver = PyPIVersion(version(package_name))
+    
+    return _get_semver_from_python_version(pypi_ver)
+
 
 def _package_version_meets_minimum(package_name: str, minimum_version: str) -> bool:
-    package_version = Version.parse(version(package_name))
-    version_result =  Version.compare(package_version, minimum_version)
+    package_version = _get_python_package_version(package_name)
+    package_minimum_version = _get_semver_from_python_version(PyPIVersion(minimum_version))
+    version_result =  Version.compare(package_version, package_minimum_version)
     if version_result < 0:
         raise AssertionError("Package {} with version {} does not meet minimum version requirement {}".format(package_name, str(package_version), minimum_version))
     return True

--- a/src/sdk/python/rtdip_sdk/pipelines/_pipeline_utils/constants.py
+++ b/src/sdk/python/rtdip_sdk/pipelines/_pipeline_utils/constants.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from importlib_metadata import version
 from .models import MavenLibrary, PyPiLibrary
 
 DEFAULT_PACKAGES = {
     "spark_delta_core": MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             ),
     "spark_delta_sharing": MavenLibrary(
                 group_id="io.delta",

--- a/src/sdk/python/rtdip_sdk/pipelines/_pipeline_utils/spark.py
+++ b/src/sdk/python/rtdip_sdk/pipelines/_pipeline_utils/spark.py
@@ -17,15 +17,20 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, TimestampType, StringType, BinaryType, LongType, MapType, IntegerType, ArrayType
 
 from .models import Libraries
+from ..._sdk_utils.compare_versions import _package_version_meets_minimum
 
 class SparkClient():
     spark_configuration: dict
     spark_libraries: Libraries
     spark_session: SparkSession
+    spark_remote: str
     
-    def __init__(self, spark_configuration: dict, spark_libraries: Libraries):
+    def __init__(self, spark_configuration: dict, spark_libraries: Libraries, spark_remote: str = None):
         self.spark_configuration = spark_configuration
         self.spark_libraries = spark_libraries
+        if spark_remote != None:
+            _package_version_meets_minimum("pyspark", "3.4.0")
+        self.spark_remote = spark_remote
         self.spark_session = self.get_spark_session()
 
     def get_spark_session(self) -> SparkSession:
@@ -45,8 +50,12 @@ class SparkClient():
                 spark = spark.master(temp_spark_configuration[spark_master])
                 temp_spark_configuration.pop(spark_master)
 
+            if self.spark_remote:
+                spark = spark.remote(self.spark_remote)
+                
             if len(self.spark_libraries.maven_libraries) > 0:
                 temp_spark_configuration["spark.jars.packages"] = ','.join(maven_package.to_string() for maven_package in self.spark_libraries.maven_libraries)
+                temp_spark_configuration["spark.jars.repositories"] = "https://oss.sonatype.org/content/repositories/iodelta-1080"
                         
             for configuration in temp_spark_configuration.items():
                 spark = spark.config(configuration[0], configuration[1])

--- a/tests/sdk/python/rtdip_sdk/_sdk_utils/test_compare_versions.py
+++ b/tests/sdk/python/rtdip_sdk/_sdk_utils/test_compare_versions.py
@@ -28,6 +28,13 @@ def test_package_package_version_meets_minimum(mocker: MockerFixture):
     result = _package_version_meets_minimum("test-package-version", "1.0.0")
     assert True
 
+def test_package_package_version_prerelease_meets_minimum(mocker: MockerFixture):
+    mock_package = MockPackageClass()
+    mock_package.version = "5.2.0rc1"
+    mocker.patch("importlib_metadata.Distribution.from_name", return_value=mock_package)
+    result = _package_version_meets_minimum("test-package-version", "5.2.0rc1")
+    assert True
+
 def test_package_version_does_not_meet_minimum(mocker: MockerFixture):
     mock_package = MockPackageClass()
     mock_package.version = "0.9.0"

--- a/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_delta.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_delta.py
@@ -15,6 +15,7 @@
 import sys
 sys.path.insert(0, '.')
 import pytest
+from importlib_metadata import version
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta import SparkDeltaDestination
 from src.sdk.python.rtdip_sdk.pipelines._pipeline_utils.models import Libraries, MavenLibrary
 from tests.sdk.python.rtdip_sdk.pipelines._pipeline_utils.spark_configuration_constants import spark_session
@@ -31,7 +32,7 @@ def test_spark_delta_write_setup():
     assert delta_destination.libraries() == Libraries(maven_libraries=[MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             )], pypi_libraries=[], pythonwheel_libraries=[])
     assert isinstance(delta_destination.settings(), dict)
     assert delta_destination.pre_write_validation()

--- a/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_delta_merge.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_delta_merge.py
@@ -15,6 +15,7 @@
 import sys
 sys.path.insert(0, '.')
 import pytest
+from importlib_metadata import version
 from src.sdk.python.rtdip_sdk._sdk_utils.compare_versions import _package_version_meets_minimum
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta_merge import SparkDeltaMergeDestination, DeltaMergeCondition, DeltaMergeConditionValues
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta import SparkDeltaDestination
@@ -33,7 +34,7 @@ def test_spark_delta_merge_write_setup(spark_session: SparkSession):
     assert delta_merge_destination.libraries() == Libraries(maven_libraries=[MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             )], pypi_libraries=[], pythonwheel_libraries=[])
     assert isinstance(delta_merge_destination.settings(), dict)
     assert delta_merge_destination.pre_write_validation()

--- a/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_pcdm_to_delta.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/destinations/spark/test_pcdm_to_delta.py
@@ -16,6 +16,7 @@ import sys
 
 sys.path.insert(0, '.')
 import pytest
+from importlib_metadata import version
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta_merge import SparkDeltaMergeDestination, DeltaMergeCondition, DeltaMergeConditionValues
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta import SparkDeltaDestination
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.pcdm_to_delta import SparkPCDMToDeltaDestination
@@ -56,7 +57,7 @@ def test_spark_pcdm_to_delta_write_setup(spark_session: SparkSession):
     assert pcdm_to_delta_destination.libraries() == Libraries(maven_libraries=[MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             )], pypi_libraries=[], pythonwheel_libraries=[])
     assert isinstance(pcdm_to_delta_destination.settings(), dict)
     assert pcdm_to_delta_destination.pre_write_validation()

--- a/tests/sdk/python/rtdip_sdk/pipelines/sources/spark/test_autoloader.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/sources/spark/test_autoloader.py
@@ -14,6 +14,7 @@
 
 import sys
 sys.path.insert(0, '.')
+from importlib_metadata import version
 import pytest
 from pytest_mock import MockerFixture
 from src.sdk.python.rtdip_sdk.pipelines.sources.spark.autoloader import DataBricksAutoLoaderSource
@@ -29,7 +30,7 @@ def test_databricks_autoloader_setup(spark_session: SparkSession):
     assert autoloader_source.libraries() == Libraries(maven_libraries=[MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             )], pypi_libraries=[], pythonwheel_libraries=[])
     assert isinstance(autoloader_source.settings(), dict)
     assert autoloader_source.pre_read_validation()

--- a/tests/sdk/python/rtdip_sdk/pipelines/sources/spark/test_delta.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/sources/spark/test_delta.py
@@ -14,6 +14,7 @@
 
 import sys
 sys.path.insert(0, '.')
+from importlib_metadata import version
 import pytest
 from src.sdk.python.rtdip_sdk.pipelines.destinations.spark.delta import SparkDeltaDestination
 from src.sdk.python.rtdip_sdk.pipelines._pipeline_utils.models import Libraries, MavenLibrary
@@ -29,7 +30,7 @@ def test_spark_delta_read_setup(spark_session: SparkSession):
     assert delta_source.libraries() == Libraries(maven_libraries=[MavenLibrary(
                 group_id="io.delta",
                 artifact_id="delta-core_2.12",
-                version="2.3.0"
+                version=version("delta-spark")
             )], pypi_libraries=[], pythonwheel_libraries=[])
     assert isinstance(delta_source.settings(), dict)
     assert delta_source.pre_read_validation()

--- a/tests/sdk/python/rtdip_sdk/pipelines/utilities/spark/test_delta_table_create.py
+++ b/tests/sdk/python/rtdip_sdk/pipelines/utilities/spark/test_delta_table_create.py
@@ -14,7 +14,7 @@
 
 import sys
 sys.path.insert(0, '.')
-
+from src.sdk.python.rtdip_sdk._sdk_utils.compare_versions import _package_version_meets_minimum
 from src.sdk.python.rtdip_sdk.pipelines.utilities.spark.delta_table_create import DeltaTableCreateUtility, DeltaTableColumn
 from tests.sdk.python.rtdip_sdk.pipelines._pipeline_utils.spark_configuration_constants import spark_session
 from pyspark.sql import SparkSession
@@ -48,10 +48,20 @@ def test_spark_delta_table_create(spark_session: SparkSession):
     assert table_describe[3][1] == "string"
     assert table_describe[4][0] == "Value"
     assert table_describe[4][1] == "float"
-    assert table_describe[7][1] == "EventDate"
-    assert table_describe[10][1] == "default.test_table_delta_create"
-    assert table_describe[11][1] == "Test Table for Delta Create"
-    assert "spark-warehouse/test_table_delta_create" in table_describe[12][1]
-    assert "delta.enableChangeDataFeed=true" in table_describe[14][1]
-    assert "delta.logRetentionDuration=7 days" in table_describe[14][1]
+    try:
+        _package_version_meets_minimum("delta-spark", "2.4.0rc1")
+        assert table_describe[7][0] == "EventDate"
+        assert table_describe[7][1] == "date"
+        assert table_describe[10][1] == "spark_catalog.default.test_table_delta_create"
+        assert table_describe[12][1] == "Test Table for Delta Create"
+        assert "spark-warehouse/test_table_delta_create" in table_describe[13][1]
+        assert "delta.enableChangeDataFeed=true" in table_describe[15][1]
+        assert "delta.logRetentionDuration=7 days" in table_describe[15][1]        
+    except:
+        assert table_describe[7][1] == "EventDate"
+        assert table_describe[10][1] == "default.test_table_delta_create"
+        assert table_describe[11][1] == "Test Table for Delta Create"
+        assert "spark-warehouse/test_table_delta_create" in table_describe[12][1]
+        assert "delta.enableChangeDataFeed=true" in table_describe[14][1]
+        assert "delta.logRetentionDuration=7 days" in table_describe[14][1]
     


### PR DESCRIPTION
Adds **preview** support of Pyspark 3.4.0 - this is due to the dependency of `delta-spark` that has only released a preview candidate(2.4.0rc1) for this version.

resolves #275 