### PR TITLE
Add Filter Parameter and TagName field mapping for OPC Publisher Transformer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,11 +15,11 @@
         "--cov=.",
         "--cov-report=xml:cov.xml",
         "tests",
-        "-vv"
+        "-v"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.testing.cwd": "${workspaceFolder}",
+    // "python.testing.cwd": "${workspaceFolder}",
     "python.analysis.extraPaths": ["${workspaceFolder}"],
     // "terminal.integrated.env.osx":{
     //     "PYTHONPATH": "${workspaceFolder}:${env:PYTHONPATH}"        

--- a/docs/domains/process_control/data_model.md
+++ b/docs/domains/process_control/data_model.md
@@ -57,7 +57,7 @@ The mapping below is performed by the [RTDIP OPC Publisher to PCDM Component](..
 
 | From Data Model | From Field | From Type | To Data Model |To Field| To Type | Mapping Logic |
 |------|----|---------|------|------|--------|-----------|
-| OPC Publisher | DisplayName | string | EVENTS| TagName | string | |
+| OPC Publisher | DisplayName | string | EVENTS| TagName | string | From Field can be specified in Component |
 | OPC Publisher | SourceTimestamp | string | EVENTS| EventTime | timestamp | Converted to a timestamp |
 | OPC Publisher | StatusCode.Symbol | string | EVENTS| Status | string | Null values can be overriden in the [RTDIP OPC Publisher to PCDM Component](../../sdk/code-reference/pipelines/transformers/spark/opc_publisher_json_to_pcdm.md) |
 | OPC Publisher | Value.Value | string | EVENTS | Value | dynamic | Converts Value into either a float number or string based on how it is received in the message |

--- a/src/sdk/python/rtdip_sdk/pipelines/transformers/spark/opc_publisher_json_to_pcdm.py
+++ b/src/sdk/python/rtdip_sdk/pipelines/transformers/spark/opc_publisher_json_to_pcdm.py
@@ -30,6 +30,7 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
         multiple_rows_per_message (optional bool): Each Dataframe Row contains an array of/multiple OPC UA messages. The list of Json will be exploded into rows in the Dataframe.
         status_null_value (optional str): If populated, will replace null values in the Status column with the specified value.
         timestamp_formats (optional list[str]): Specifies the timestamp formats to be used for converting the timestamp string to a Timestamp Type. For more information on formats, refer to this [documentation.](https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html)
+        device_id_filter (optional str): Enables filtering by Device Id that is sent in field `systemProperties.iothub-connection-device-id` of the message
         module_filter (optional str): Enables filtering by Module that is sent in field `systemProperties.iothub-connection-module-id` of the message
     '''
     data: DataFrame
@@ -39,9 +40,10 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
     status_null_value: str
     change_type_value: str
     timestamp_formats: list
+    device_id_filter: str
     module_filter: str
 
-    def __init__(self, data: DataFrame, source_column_name: str, multiple_rows_per_message: bool = True, tagname_field: str = "DisplayName", status_null_value: str = None, change_type_value: str = "insert", timestamp_formats: list = ["yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ssX"], module_filter: str = None) -> None: # NOSONAR
+    def __init__(self, data: DataFrame, source_column_name: str, multiple_rows_per_message: bool = True, tagname_field: str = "DisplayName", status_null_value: str = None, change_type_value: str = "insert", timestamp_formats: list = ["yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ssX"], device_id_filter: str = None, module_filter: str = None) -> None: # NOSONAR
         self.data = data
         self.source_column_name = source_column_name
         self.multiple_rows_per_message = multiple_rows_per_message
@@ -49,6 +51,7 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
         self.status_null_value = status_null_value
         self.change_type_value = change_type_value
         self.timestamp_formats = timestamp_formats
+        self.device_id_filter = device_id_filter
         self.module_filter = module_filter
 
     @staticmethod
@@ -88,6 +91,9 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
             df = (self.data
                 .withColumn(self.source_column_name, from_json(col(self.source_column_name), StringType()))
             )
+
+        if self.device_id_filter != None:
+            df = df.where(col("systemProperties.iothub-connection-device-id") == self.device_id_filter)           
 
         if self.module_filter != None:
             df = df.where(col("systemProperties.iothub-connection-module-id") == self.module_filter)           

--- a/src/sdk/python/rtdip_sdk/pipelines/transformers/spark/opc_publisher_json_to_pcdm.py
+++ b/src/sdk/python/rtdip_sdk/pipelines/transformers/spark/opc_publisher_json_to_pcdm.py
@@ -27,25 +27,29 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
     Args:
         data (DataFrame): Dataframe containing the column with Json OPC UA data
         source_column_name (str): Spark Dataframe column containing the OPC Publisher Json OPC UA data
-        multiple_rows_per_message (bool): Each Dataframe Row contains an array of/multiple OPC UA messages. The list of Json will be exploded into rows in the Dataframe.
-        status_null_value (str): If populated, will replace null values in the Status column with the specified value.
-        timestamp_formats (list[str]): Specifies the timestamp formats to be used for converting the timestamp string to a Timestamp Type. For more information on formats, refer to this [documentation.](https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html)
-
+        multiple_rows_per_message (optional bool): Each Dataframe Row contains an array of/multiple OPC UA messages. The list of Json will be exploded into rows in the Dataframe.
+        status_null_value (optional str): If populated, will replace null values in the Status column with the specified value.
+        timestamp_formats (optional list[str]): Specifies the timestamp formats to be used for converting the timestamp string to a Timestamp Type. For more information on formats, refer to this [documentation.](https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html)
+        module_filter (optional str): Enables filtering by Module that is sent in field `systemProperties.iothub-connection-module-id` of the message
     '''
     data: DataFrame
     source_column_name: str
     multiple_rows_per_message: bool
+    tagname_field: str
     status_null_value: str
     change_type_value: str
     timestamp_formats: list
+    module_filter: str
 
-    def __init__(self, data: DataFrame, source_column_name: str, multiple_rows_per_message: bool = True, status_null_value: str = None, change_type_value: str = "insert", timestamp_formats: list = ["yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ssX"]) -> None: # NOSONAR
+    def __init__(self, data: DataFrame, source_column_name: str, multiple_rows_per_message: bool = True, tagname_field: str = "DisplayName", status_null_value: str = None, change_type_value: str = "insert", timestamp_formats: list = ["yyyy-MM-dd'T'HH:mm:ss.SSSX", "yyyy-MM-dd'T'HH:mm:ssX"], module_filter: str = None) -> None: # NOSONAR
         self.data = data
         self.source_column_name = source_column_name
         self.multiple_rows_per_message = multiple_rows_per_message
+        self.tagname_field = tagname_field
         self.status_null_value = status_null_value
         self.change_type_value = change_type_value
         self.timestamp_formats = timestamp_formats
+        self.module_filter = module_filter
 
     @staticmethod
     def system_type():
@@ -85,9 +89,12 @@ class OPCPublisherJsonToPCDMTransformer(TransformerInterface):
                 .withColumn(self.source_column_name, from_json(col(self.source_column_name), StringType()))
             )
 
+        if self.module_filter != None:
+            df = df.where(col("systemProperties.iothub-connection-module-id") == self.module_filter)           
+
         df = (df
             .withColumn("OPCUA", from_json(col(self.source_column_name), OPC_PUBLISHER_SCHEMA))
-            .withColumn("TagName", (col("OPCUA.DisplayName")))
+            .withColumn("TagName", (col("OPCUA.{}".format(self.tagname_field))))
             .withColumn("EventTime", coalesce(*[to_timestamp(col("OPCUA.Value.SourceTimestamp"), f) for f in self.timestamp_formats]))   
             .withColumn("Value", col("OPCUA.Value.Value"))
             .withColumn("ValueType", when(col("Value").cast("float").isNotNull(), "float")


### PR DESCRIPTION
Add option to filter iot hub messages by module and provide an option to specify the field to be used for TagName mapping. Resolves #295 