### PR TITLE
API Convert NaN to None in JSON Response

### DIFF
--- a/src/api/v1/interpolate.py
+++ b/src/api/v1/interpolate.py
@@ -17,6 +17,7 @@ from src.api.FastAPIApp import api_v1_router
 from fastapi import HTTPException, Depends, Body
 import nest_asyncio
 from pandas.io.json import build_table_schema
+import numpy as np
 from src.sdk.python.rtdip_sdk.queries import interpolate
 from src.api.v1.models import BaseQueryParams, ResampleInterpolateResponse, HTTPError, RawQueryParams, TagsQueryParams, TagsBodyParams, ResampleQueryParams, InterpolateQueryParams
 import src.api.v1.common
@@ -32,9 +33,9 @@ def interpolate_events_get(base_query_parameters, raw_query_parameters, tag_quer
             tag_query_parameters=tag_query_parameters,
             interpolate_query_parameters=interpolate_parameters
         )
-
+        
         data = interpolate.get(connection, parameters)
-        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/v1/interpolation_at_time.py
+++ b/src/api/v1/interpolation_at_time.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import numpy as np
 from src.api.FastAPIApp import api_v1_router
 from fastapi import HTTPException, Depends, Body
 import nest_asyncio
@@ -32,7 +33,7 @@ def interpolation_at_time_events_get(base_query_parameters, tag_query_parameters
         )
 
         data = interpolation_at_time.get(connection, parameters)
-        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/v1/metadata.py
+++ b/src/api/v1/metadata.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import numpy as np
 from pandas.io.json import build_table_schema
 from fastapi import Query, HTTPException, Depends, Body
 import nest_asyncio
@@ -30,7 +31,7 @@ def metadata_retrieval_get(query_parameters, metadata_query_parameters):
         (connection, parameters) = common.common_api_setup_tasks(query_parameters, metadata_query_parameters=metadata_query_parameters)
 
         data = metadata.get(connection, parameters)
-        return MetadataResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return MetadataResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/v1/raw.py
+++ b/src/api/v1/raw.py
@@ -14,7 +14,7 @@
 
 
 import logging
-from logging import Logger
+import numpy as np
 from pandas.io.json import build_table_schema
 from fastapi import Query, HTTPException, Depends, Body
 import nest_asyncio
@@ -31,7 +31,7 @@ def raw_events_get(base_query_parameters, raw_query_parameters, tag_query_parame
         (connection, parameters) = src.api.v1.common.common_api_setup_tasks(base_query_parameters, raw_query_parameters=raw_query_parameters, tag_query_parameters=tag_query_parameters)
         
         data = raw.get(connection, parameters)
-        return RawResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return RawResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/v1/resample.py
+++ b/src/api/v1/resample.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import numpy as np
 from requests import request
 from src.api.FastAPIApp import api_v1_router
 from fastapi import HTTPException, Depends, Body
@@ -30,7 +31,7 @@ def resample_events_get(base_query_parameters, raw_query_parameters, tag_query_p
         (connection, parameters) = src.api.v1.common.common_api_setup_tasks(base_query_parameters, raw_query_parameters=raw_query_parameters, tag_query_parameters=tag_query_parameters,resample_query_parameters=resample_parameters)
 
         data = resample.get(connection, parameters)
-        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/api/v1/time_weighted_average.py
+++ b/src/api/v1/time_weighted_average.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 from src.api.FastAPIApp import api_v1_router
 from fastapi import HTTPException, Depends, Body
 import nest_asyncio
@@ -20,7 +21,7 @@ def time_weighted_average_events_get(base_query_parameters, raw_query_parameters
 
         data = time_weighted_average.get(connection, parameters)
         data = data.reset_index()
-        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.to_dict(orient="records"))
+        return ResampleInterpolateResponse(schema=build_table_schema(data, index=False, primary_key=False), data=data.replace({np.nan: None}).to_dict(orient="records"))
     except Exception as e:
         logging.error(str(e))
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
APIs would fail if a float column has NaN due to invalid JSON(NaN is not valid float json). Convert NaN to None in responses.