### PR TITLE
Remove pyodbc from package and update docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           mkdocs build --strict
 
-  job_lint_black:
+  job_python_lint_black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -56,13 +56,16 @@ Installing the RTDIP can be done using a package installer, such as [Pip](https:
         micromamba self-update
 
 ### ODBC
-To use pyodbc or turbodbc python libraries, ensure that the required ODBC driver is installed as per these [instructions](https://docs.microsoft.com/en-us/azure/databricks/integrations/bi/jdbc-odbc-bi#download-the-odbc-driver).
+To use pyodbc or turbodbc python libraries, ensure it is installed as per the below and the ODBC driver is installed as per these [instructions](https://docs.microsoft.com/en-us/azure/databricks/integrations/bi/jdbc-odbc-bi#download-the-odbc-driver).
 
 === "Pyodbc"
-    If you plan to use pyodbc, Microsoft Visual C++ 14.0 or greater is required. Get it from [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+    1. If you plan to use pyodbc, Microsoft Visual C++ 14.0 or greater is required. Get it from [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+    1. If you are using linux, install unixodbc as per these [instructions.](https://github.com/mkleehammer/pyodbc/wiki/Install)
+    1. Install the `pyodbc` python package into your python environment.
 
 === "Turbodbc"
-    To use turbodbc python library, ensure to follow the [Turbodbc Getting Started](https://turbodbc.readthedocs.io/en/latest/pages/getting_started.html) section and ensure that [Boost](https://turbodbc.readthedocs.io/en/latest/pages/getting_started.html) is installed correctly.
+    1. To use turbodbc python library, ensure to follow the [Turbodbc Getting Started](https://turbodbc.readthedocs.io/en/latest/pages/getting_started.html) section and ensure that [Boost](https://turbodbc.readthedocs.io/en/latest/pages/getting_started.html) is installed correctly. 
+    1. Install the `turbodbc` python package into your python environment.
 
 ### Spark Connect
 

--- a/docs/sdk/queries/connectors.md
+++ b/docs/sdk/queries/connectors.md
@@ -24,7 +24,10 @@ Replace **server_hostname**, **http_path** and **access_token** with your own in
 
 ### PYODBC SQL Connector
 
-[PYDOBC](https://pypi.org/project/pyodbc/) is a popular python package for querying data using ODBC. Refer to their [documentation](https://github.com/mkleehammer/pyodbc/wiki) for more information about pyodbc and how you can leverage it in your code.
+[PYDOBC](https://pypi.org/project/pyodbc/) is a popular python package for querying data using ODBC. Refer to their [documentation](https://github.com/mkleehammer/pyodbc/wiki) for more information about pyodbc, how to install it and how you can leverage it in your code.
+
+!!! Warning
+    The RTDIP SDK does not specify `pyodbc` as one of its package dependencies. It will need to be installed into your environment separately.
 
 View information about how pyodbc is implemented in the RTDIP SDK [here.](../code-reference/query/pyodbc-sql-connector.md)
 
@@ -44,6 +47,9 @@ Replace **server_hostname**, **http_path** and **access_token** with your own in
 ### TURBODBC SQL Connector 
 
 Turbodbc is a powerful python ODBC package that has advanced options for querying performance. Find out more about installing it on your operation system and what Turbodbc can do [here](https://turbodbc.readthedocs.io/en/latest/) and refer to this [documentation](../code-reference/query/turbodbc-sql-connector.md) for more information about how it is implemented in the RTDIP SDK.
+
+!!! Warning
+    The RTDIP SDK does not specify `turbodbc` as one of its package dependencies. It will need to be installed into your environment separately.
 
 ```python
 from rtdip_sdk.connectors import TURBODBCSQLConnection

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ long_description = (here / "PYPI-README.md").read_text()
 INSTALL_REQUIRES = [
     "databricks-sql-connector==2.9.2",
     "azure-identity==1.12.0",
-    "pyodbc==4.0.39",
     "pandas>=1.5.2,<3.0.0",
     "jinja2==3.1.2",
     "importlib_metadata>=1.0.0",


### PR DESCRIPTION
Removed pyodbc due to new requirement by the package to install unixodbc. This causes inconsistencies in rtdip-sdk depending on the environment it is run in. Due to this, the package is removed and it is the user's responsibility to ensure pyodbc is installed correctly in their environment.