### PR TITLE
Feature/batch api updates

### DIFF
--- a/src/api/v1/batch.py
+++ b/src/api/v1/batch.py
@@ -38,18 +38,18 @@ import pandas as pd
 
 
 ROUTE_FUNCTION_MAPPING = {
-    "/api/v1/events/raw": "raw",
-    "/api/v1/events/latest": "latest",
-    "/api/v1/events/resample": "resample",
-    "/api/v1/events/plot": "plot",
-    "/api/v1/events/interpolate": "interpolate",
-    "/api/v1/events/interpolationattime": "interpolationattime",
-    "/api/v1/events/circularaverage": "circularaverage",
-    "/api/v1/events/circularstandarddeviation": "circularstandarddeviation",
-    "/api/v1/events/timeweightedaverage": "timeweightedaverage",
-    "/api/v1/events/summary": "summary",
-    "/api/v1/events/metadata": "metadata",
-    "/api/v1/sql/execute": "execute",
+    "/events/raw": "raw",
+    "/events/latest": "latest",
+    "/events/resample": "resample",
+    "/events/plot": "plot",
+    "/events/interpolate": "interpolate",
+    "/events/interpolationattime": "interpolationattime",
+    "/events/circularaverage": "circularaverage",
+    "/events/circularstandarddeviation": "circularstandarddeviation",
+    "/events/timeweightedaverage": "timeweightedaverage",
+    "/events/summary": "summary",
+    "/events/metadata": "metadata",
+    "/sql/execute": "sql",
 }
 
 

--- a/tests/api/v1/api_test_objects.py
+++ b/tests/api/v1/api_test_objects.py
@@ -239,18 +239,33 @@ BATCH_MOCKED_PARAMETER_DICT = {
 BATCH_POST_PAYLOAD_SINGLE_WITH_GET = {
     "requests": [
         {
-            "url": "/api/v1/events/summary",
+            "url": "/events/summary",
             "method": "GET",
             "headers": TEST_HEADERS,
-            "params": SUMMARY_MOCKED_PARAMETER_DICT,
+            "params": SUMMARY_MOCKED_PARAMETER_DICT.copy(),
         }
     ]
 }
 
+BATCH_POST_PAYLOAD_SINGLE_WITH_MISSING_BUSINESS_UNIT = {
+    "requests": [
+        {
+            "url": "/events/summary",
+            "method": "GET",
+            "headers": TEST_HEADERS,
+            "params": SUMMARY_MOCKED_PARAMETER_DICT.copy(),
+        }
+    ]
+}
+BATCH_POST_PAYLOAD_SINGLE_WITH_MISSING_BUSINESS_UNIT["requests"][0]["params"].pop(
+    "business_unit"
+)
+
+
 BATCH_POST_PAYLOAD_SINGLE_WITH_POST = {
     "requests": [
         {
-            "url": "/api/v1/events/raw",
+            "url": "/events/raw",
             "method": "POST",
             "headers": TEST_HEADERS,
             "params": RAW_MOCKED_PARAMETER_DICT,
@@ -262,7 +277,7 @@ BATCH_POST_PAYLOAD_SINGLE_WITH_POST = {
 BATCH_POST_PAYLOAD_SINGLE_WITH_GET_ERROR_DICT = {
     "requests": [
         {
-            "url": "an_unsupported_route",
+            "url": "/api/v1/events/raw",  # Invalid URL since it should be /events/raw
             "method": "GET",
             "headers": TEST_HEADERS,
             "params": SUMMARY_MOCKED_PARAMETER_DICT,
@@ -273,7 +288,7 @@ BATCH_POST_PAYLOAD_SINGLE_WITH_GET_ERROR_DICT = {
 BATCH_POST_PAYLOAD_SINGLE_WITH_POST_ERROR_DICT = {
     "requests": [
         {
-            "url": "/api/v1/events/raw",
+            "url": "/events/raw",
             "method": "POST",
             "headers": TEST_HEADERS,
             "params": RAW_MOCKED_PARAMETER_DICT,
@@ -285,17 +300,37 @@ BATCH_POST_PAYLOAD_SINGLE_WITH_POST_ERROR_DICT = {
 BATCH_POST_PAYLOAD_MULTIPLE = {
     "requests": [
         {
-            "url": "/api/v1/events/summary",
+            "url": "/events/summary",
             "method": "GET",
             "headers": TEST_HEADERS,
             "params": SUMMARY_MOCKED_PARAMETER_DICT,
         },
         {
-            "url": "/api/v1/events/raw",
+            "url": "/events/raw",
             "method": "POST",
             "headers": TEST_HEADERS,
             "params": RAW_MOCKED_PARAMETER_DICT,
             "body": RESAMPLE_POST_BODY_MOCKED_PARAMETER_DICT,
+        },
+    ]
+}
+
+BATCH_POST_PAYLOAD_ONE_SUCCESS_ONE_FAIL = {
+    "requests": [
+        {
+            "url": "/sql/execute",
+            "method": "POST",
+            "headers": TEST_HEADERS,
+            "params": {},
+            "body": {
+                "sql_statement": "SELECT * FROM 1",
+            },
+        },
+        {
+            "url": "/events/raw",
+            "method": "GET",
+            "headers": TEST_HEADERS,
+            "params": {},
         },
     ]
 }


### PR DESCRIPTION
Contains updates to the batch API route, with corresponding tests for each of the changes:

- Main logic change: Allows for fully defined and confidential tables in batch
    - When parameters fully defined for a request, runs sdk function directly. 
    - Lookup function only used when parameters missing (e.g. no business_unit)
- Refactor of batch route to have separate functions for parsing request parameters and running the functions
- Allows for mixed results from batch: 
    - Some requests can succeed and others fail in the same request
    - Helpful error messages so user can see which fail
- Route mapping update
    - To shorten strings e.g. now  '/events/raw' when was previously '/api/v1/events/raw'
    - SQL route mapping fix, was previously misnamed
   