### PR TITLE
Remove Pyspark 3.5.2 from github actions test list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,22 +27,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
-        pyspark:
-          [
-            "3.3.0",
-            "3.3.1",
-            "3.3.2",
-            "3.4.0",
-            "3.4.1",
-            "3.5.0",
-            "3.5.1",
-            "3.5.2",
-          ]
+        pyspark: ["3.3.0", "3.3.1", "3.3.2", "3.4.0", "3.4.1", "3.5.0", "3.5.1"]
         exclude:
-          - pyspark: "3.5.2"
-            python-version: "3.9"
-          - pyspark: "3.5.2"
-            python-version: "3.10"
           - pyspark: "3.5.1"
             python-version: "3.9"
           - pyspark: "3.5.1"
@@ -79,8 +65,6 @@ jobs:
           - pyspark: "3.5.0"
             delta-spark: "3.0.0"
           - pyspark: "3.5.1"
-            delta-spark: "3.0.0"
-          - pyspark: "3.5.2"
             delta-spark: "3.0.0"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Removed as not available on anaconda